### PR TITLE
Initialize semaphore to prevent random lock-up on first use

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -76,6 +76,7 @@ void MQTTClientInit(MQTTClient *c, Network *network, unsigned int command_timeou
    TimerInit(&c->ping_timer);
 #if defined(MQTT_TASK)
    QueueInit(&c->reply);
+   MutexInit(&c->write_mutex);
 #endif
 }
 


### PR DESCRIPTION
Due to missing initialisation, depending on the random data at allocated location for mutex MutexLock would work or wait forever.