### PR TITLE
Fix topic handlers cleanup during unsubscribe call

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -15,6 +15,8 @@
  *******************************************************************************/
 #include "MQTTClient.h"
 
+#include <string.h>
+
 static void NewMessageData(MessageData *md, MQTTString *aTopicName, MQTTMessage *aMessage)
 {
    md->topicName = aTopicName;
@@ -529,6 +531,17 @@ int MQTTUnsubscribe(MQTTClient *c, const char *topicFilter)
    }
    else
       rc = FAILURE;
+
+   // We have to find the right message handler and remove it.
+   for (size_t i = 0; i < MAX_MESSAGE_HANDLERS; ++i)
+   {
+      if (c->messageHandlers[i].topicFilter != NULL && !strcmp(c->messageHandlers[i].topicFilter, topicFilter))
+      {
+         c->messageHandlers[i].topicFilter = NULL;
+         c->messageHandlers[i].fp = NULL;
+         break;
+      }
+   }
 
 exit:
    return rc;


### PR DESCRIPTION
When unsubscription is taking place, pointers to handlers still
populating the list.

This causes two issues:

1. Dangling pointer - when next subscribe request successed, list will
be iterated and handler called with argument that can be deleted at this
stage.

2. Spurious handler call - when subscribed again with the same handler,
it will be called twice during packet processing.